### PR TITLE
Update to sila java 0.10.0

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "extern/sila_java"]
-	path = extern/sila_java
-	url = https://gitlab.com/SiLA2/sila_java.git

--- a/orchestrator-client/pom.xml
+++ b/orchestrator-client/pom.xml
@@ -19,7 +19,7 @@
 
     <properties>
         <java.version>11</java.version>
-        <sila.version>0.6.0</sila.version>
+        <sila.version>0.10.0</sila.version>
         <protobuf.version>3.19.4</protobuf.version>
         <grpc.version>1.43.2</grpc.version>
         <logback.version>1.2.9</logback.version>
@@ -48,13 +48,6 @@
 
     <dependencyManagement>
         <dependencies>
-            <dependency>
-                <groupId>org.sila-standard</groupId>
-                <artifactId>sila_java</artifactId>
-                <version>${sila.version}</version>
-                <type>pom</type>
-                <scope>compile</scope>
-            </dependency>
             <dependency>
                 <groupId>com.google.protobuf</groupId>
                 <artifactId>protobuf-java</artifactId>
@@ -107,13 +100,9 @@
     <dependencies>
         <dependency>
             <groupId>org.sila-standard.sila_java.library</groupId>
-            <artifactId>core</artifactId>
-            <version>${sila.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.sila-standard.sila_java.library</groupId>
             <artifactId>manager</artifactId>
             <version>${sila.version}</version>
+            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/orchestrator-client/src/main/java/de/fau/clients/orchestrator/OrchestratorGui.java
+++ b/orchestrator-client/src/main/java/de/fau/clients/orchestrator/OrchestratorGui.java
@@ -58,9 +58,11 @@ import javax.swing.tree.DefaultMutableTreeNode;
 import javax.swing.tree.TreePath;
 import lombok.extern.slf4j.Slf4j;
 import org.slf4j.LoggerFactory;
+import sila_java.library.manager.server_management.ServerConnectionException;
+
 import static sila_java.library.core.encryption.EncryptionUtils.readCertificate;
 import static sila_java.library.core.encryption.EncryptionUtils.writeCertificateToString;
-import sila_java.library.manager.ServerAdditionException;
+
 
 /**
  * The main GUI window and execution entry point of the client. It is advised to use the NetBeans
@@ -1556,7 +1558,7 @@ public class OrchestratorGui extends javax.swing.JFrame {
 
                 try {
                     connectionManager.reconnectServer(serverNode.getServerUuid());
-                } catch (ServerAdditionException ex) {
+                } catch (ServerConnectionException ex) {
                     log.warn(ex.getMessage());
                 }
             }

--- a/orchestrator-client/src/main/java/de/fau/clients/orchestrator/cli/CommandlineControls.java
+++ b/orchestrator-client/src/main/java/de/fau/clients/orchestrator/cli/CommandlineControls.java
@@ -15,7 +15,7 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.UUID;
 import lombok.NonNull;
-import sila_java.library.manager.ServerAdditionException;
+import sila_java.library.manager.server_management.ServerConnectionException;
 import sila_java.library.manager.models.Server;
 
 /**
@@ -97,7 +97,7 @@ public final class CommandlineControls {
             try {
                 hp = HostAndPort.fromString(hostPortStr);
                 conManager.addServer(hp.getHost(), hp.getPort());
-            } catch (ServerAdditionException ex) {
+            } catch (ServerConnectionException ex) {
                 System.err.println("Could not connect to '" + hostPortStr + "': " + ex.getMessage());
             } catch (IllegalArgumentException ex) {
                 System.err.println(ex.getMessage());

--- a/orchestrator-client/src/main/java/de/fau/clients/orchestrator/ctx/ConnectionManager.java
+++ b/orchestrator-client/src/main/java/de/fau/clients/orchestrator/ctx/ConnectionManager.java
@@ -30,8 +30,18 @@ public class ConnectionManager implements AutoCloseable, ServerListener {
         return ConnectionManagerHolder.INSTANCE;
     }
 
-    @Deprecated
+    /**
+     * Connect to a server using a trusted certificate or through an unsecure connection
+     * if {@link ServerManager#setAllowUnsecureConnection(boolean)} has been set to true.
+     * Note that setting this to true is deprecated and not allowed by the SiLA Standard and should only be used for
+     * test purposes.
+     * @param host the server host
+     * @param port the server host
+     * @return the server UUID if connection is successful
+     * @throws ServerConnectionException if unable to connect to the server or is not a valid SiLA Server
+     */
     public UUID addServer(final String host, int port) throws ServerConnectionException {
+        // method is marked as deprecated but is not, sila_java 0.11.0 will fix this problem
         serverManager.addServer(host, port);
         for (final Server server : serverManager.getServers().values()) {
             if (server.getHost().equals(host) && server.getPort() == port) {
@@ -45,6 +55,17 @@ public class ConnectionManager implements AutoCloseable, ServerListener {
         return null;
     }
 
+    /**
+     * Connect to a server using a untrusted (self-signed) certificate or through an unsecure connection
+     * if {@link ServerManager#setAllowUnsecureConnection(boolean)} has been set to true.
+     * Note that setting this to true is deprecated and not allowed by the SiLA Standard and should only be used for
+     * test purposes.
+     * @param host the server host
+     * @param port the server host
+     * @param cert the server untrusted (self-signed) certificate
+     * @return the server UUID if connection is successful
+     * @throws ServerConnectionException if unable to connect to the server or is not a valid SiLA Server
+     */
     public UUID addServer(final String host, int port, String cert) throws ServerConnectionException {
         serverManager.addServer(host, port, cert);
         for (final Server server : serverManager.getServers().values()) {

--- a/orchestrator-client/src/main/java/de/fau/clients/orchestrator/ctx/ConnectionManager.java
+++ b/orchestrator-client/src/main/java/de/fau/clients/orchestrator/ctx/ConnectionManager.java
@@ -7,7 +7,7 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CopyOnWriteArrayList;
 import lombok.NonNull;
-import sila_java.library.manager.ServerAdditionException;
+import sila_java.library.manager.server_management.ServerConnectionException;
 import sila_java.library.manager.ServerListener;
 import sila_java.library.manager.ServerManager;
 import sila_java.library.manager.models.Server;
@@ -31,7 +31,7 @@ public class ConnectionManager implements AutoCloseable, ServerListener {
     }
 
     @Deprecated
-    public UUID addServer(final String host, int port) throws ServerAdditionException {
+    public UUID addServer(final String host, int port) throws ServerConnectionException {
         serverManager.addServer(host, port);
         for (final Server server : serverManager.getServers().values()) {
             if (server.getHost().equals(host) && server.getPort() == port) {
@@ -45,7 +45,7 @@ public class ConnectionManager implements AutoCloseable, ServerListener {
         return null;
     }
 
-    public UUID addServer(final String host, int port, String cert) throws ServerAdditionException {
+    public UUID addServer(final String host, int port, String cert) throws ServerConnectionException {
         serverManager.addServer(host, port, cert);
         for (final Server server : serverManager.getServers().values()) {
             if (server.getHost().equals(host) && server.getPort() == port) {
@@ -65,7 +65,7 @@ public class ConnectionManager implements AutoCloseable, ServerListener {
         connectionListenerList.forEach(listener -> listener.onServerConnectionAdded(serverCtx));
     }
 
-    public void reconnectServer(@NonNull final UUID serverUuid) throws ServerAdditionException {
+    public void reconnectServer(@NonNull final UUID serverUuid) throws ServerConnectionException {
         final ServerContext serverCtx = serverMap.get(serverUuid);
         if (serverCtx != null) {
             final Server server = serverCtx.getServer();

--- a/orchestrator-client/src/main/java/de/fau/clients/orchestrator/ctx/FeatureContext.java
+++ b/orchestrator-client/src/main/java/de/fau/clients/orchestrator/ctx/FeatureContext.java
@@ -83,6 +83,10 @@ public class FeatureContext implements FullyQualifiedIdentifieable, Comparable<F
         return commandMap.get(commandIdentifier);
     }
 
+    public PropertyContext getPropertyCtx(@NonNull final String propertyIdentifier) {
+        return propertyMap.get(propertyIdentifier);
+    }
+
     public DataTypeType getElement(@NonNull final String dataTypeTypeIdentifier) {
         return dataTypeTypeMap.get(dataTypeTypeIdentifier);
     }

--- a/orchestrator-client/src/main/java/de/fau/clients/orchestrator/ctx/FeatureContext.java
+++ b/orchestrator-client/src/main/java/de/fau/clients/orchestrator/ctx/FeatureContext.java
@@ -62,6 +62,11 @@ public class FeatureContext implements FullyQualifiedIdentifieable, Comparable<F
         return feature;
     }
 
+    /**
+     * Get feature identifier. This method should only be used for informational/display purposes.
+     * Use {@link FeatureContext#getFullyQualifiedIdentifier()} for identification/internal use.
+     * @return the feature identifier
+     */
     public String getFeatureId() {
         return feature.getIdentifier();
     }

--- a/orchestrator-client/src/main/java/de/fau/clients/orchestrator/ctx/ServerContext.java
+++ b/orchestrator-client/src/main/java/de/fau/clients/orchestrator/ctx/ServerContext.java
@@ -50,8 +50,8 @@ public class ServerContext {
         return (server.getConnectionType() == Server.ConnectionType.SERVER_INITIATED);
     }
 
-    public FeatureContext getFeatureCtx(@NonNull final String featureIdentifier) {
-        return featureMap.get(featureIdentifier);
+    public FeatureContext getFeatureCtx(@NonNull final String fullyQualifiedFeatureIdentifier) {
+        return featureMap.get(fullyQualifiedFeatureIdentifier);
     }
 
     public Collection<FeatureContext> getFeatureCtxList() {

--- a/orchestrator-client/src/main/java/de/fau/clients/orchestrator/ctx/ServerContext.java
+++ b/orchestrator-client/src/main/java/de/fau/clients/orchestrator/ctx/ServerContext.java
@@ -30,7 +30,7 @@ public class ServerContext {
         for (final Feature feat : this.server.getFeatures()) {
             final boolean isCore = feat.getCategory().startsWith(CATEGORY_CORE);
             final FeatureContext featCtx = new FeatureContext(this, feat, isCore);
-            featureMap.put(feat.getIdentifier(), featCtx);
+            featureMap.put(featCtx.getFullyQualifiedIdentifier(), featCtx);
         }
     }
 

--- a/orchestrator-client/src/main/java/de/fau/clients/orchestrator/nodes/ConstraintBasicNodeFactory.java
+++ b/orchestrator-client/src/main/java/de/fau/clients/orchestrator/nodes/ConstraintBasicNodeFactory.java
@@ -578,12 +578,12 @@ class ConstraintBasicNodeFactory {
                 validator = () -> (strField.getText().length() == len);
                 conditionDesc = "= " + len;
             } else if (constraints.getFullyQualifiedIdentifier() != null) {
-                final String fqiType = constraints.getFullyQualifiedIdentifier();
+                final FullyQualifiedIdentifier fqiType = FullyQualifiedIdentifier.fromString(constraints.getFullyQualifiedIdentifier());
                 validator = () -> (ValidatorUtils.isFullyQualifiedIdentifierValid(
                         fqiType,
                         strField.getText(),
                         featCtx));
-                conditionDesc = fqiType;
+                conditionDesc = fqiType.toString();
             } else {
                 final BigInteger min = constraints.getMinimalLength();
                 final BigInteger max = constraints.getMaximalLength();

--- a/orchestrator-client/src/main/java/de/fau/clients/orchestrator/nodes/FullyQualifiedIdentifier.java
+++ b/orchestrator-client/src/main/java/de/fau/clients/orchestrator/nodes/FullyQualifiedIdentifier.java
@@ -22,6 +22,15 @@ public enum FullyQualifiedIdentifier {
         this.sectionCount = sections;
     }
 
+    public static FullyQualifiedIdentifier fromString(final String identifier) {
+        for (FullyQualifiedIdentifier b : FullyQualifiedIdentifier.values()) {
+            if (b.identifier.equalsIgnoreCase(identifier)) {
+                return b;
+            }
+        }
+        throw new RuntimeException("Invalid enum identifier " + identifier);
+    }
+
     /**
      * Gets the number of sections in the Fully Qualified Identifier URI string.
      *

--- a/orchestrator-client/src/main/java/de/fau/clients/orchestrator/tasks/CommandTask.java
+++ b/orchestrator-client/src/main/java/de/fau/clients/orchestrator/tasks/CommandTask.java
@@ -77,7 +77,7 @@ public class CommandTask extends QueueTask {
         final FeatureContext featCtx = commandCtx.getFeatureCtx();
         this.commandModel = new CommandTaskModel(
                 featCtx.getServerUuid(),
-                featCtx.getFeatureId(),
+                featCtx.getFullyQualifiedIdentifier(),
                 this.cmdCtx.getCommand().getIdentifier());
 
         if (featCtx.getServerCtx().isOnline()) {
@@ -101,7 +101,7 @@ public class CommandTask extends QueueTask {
             return false;
         }
 
-        final FeatureContext featCtx = serverCtx.getFeatureCtx(commandModel.getFeatureId());
+        final FeatureContext featCtx = serverCtx.getFeatureCtx(commandModel.getFullyQualifiedFeatureIdentifier());
         if (featCtx != null) {
             final CommandContext tmpCmdCtx = featCtx.getCommandCtx(commandModel.getCommandId());
             if (tmpCmdCtx != null) {
@@ -109,7 +109,7 @@ public class CommandTask extends QueueTask {
                 return true;
             }
         }
-        log.warn("Feature " + commandModel.getFeatureId() + " for " + commandModel.getCommandId()
+        log.warn("Feature " + commandModel.getFullyQualifiedFeatureIdentifier() + " for " + commandModel.getCommandId()
                 + " not found on server.");
         return false;
     }
@@ -326,7 +326,7 @@ public class CommandTask extends QueueTask {
                 : SiLACall.Type.UNOBSERVABLE_COMMAND;
         final SiLACall.Builder callBuilder = new SiLACall.Builder(
                 commandModel.getServerUuid(),
-                commandModel.getFeatureId(),
+                commandModel.getFullyQualifiedFeatureIdentifier(),
                 commandModel.getCommandId(),
                 callType
         );

--- a/orchestrator-client/src/main/java/de/fau/clients/orchestrator/tasks/CommandTaskModel.java
+++ b/orchestrator-client/src/main/java/de/fau/clients/orchestrator/tasks/CommandTaskModel.java
@@ -7,7 +7,10 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.databind.JsonNode;
 import java.util.UUID;
-import lombok.NonNull;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
 
 /**
@@ -18,55 +21,35 @@ import lombok.extern.slf4j.Slf4j;
  * @see TaskModel
  */
 @Slf4j
+@Getter
+@ToString
 @JsonInclude(Include.NON_NULL)
-@JsonPropertyOrder({"serverUuid", "featureId", "commandId", "commandParams"})
+@JsonPropertyOrder({"serverUuid", "fullyQualifiedFeatureIdentifier", "commandId", "commandParams"})
 public class CommandTaskModel extends TaskModel {
 
-    private UUID serverUuid;
-    private final String featureId;
+    private final String fullyQualifiedFeatureIdentifier;
     private final String commandId;
+
+    @Setter
+    private UUID serverUuid;
+    @Setter
     private JsonNode commandParams = null;
 
+    /**
+     *
+     * @param serverUuid the Server UUID
+     * @param fullyQualifiedFeatureIdentifier the Fully Qualified Feature Identifier
+     * @param commandId the command identifier
+     */
     @JsonCreator
     public CommandTaskModel(
             @JsonProperty("serverUuid") final UUID serverUuid,
-            @JsonProperty("featureId") final String featureId,
+            @JsonProperty("fullyQualifiedFeatureIdentifier") final String fullyQualifiedFeatureIdentifier,
             @JsonProperty("commandId") final String commandId
     ) {
         this.serverUuid = serverUuid;
-        this.featureId = featureId;
+        this.fullyQualifiedFeatureIdentifier = fullyQualifiedFeatureIdentifier;
         this.commandId = commandId;
     }
 
-    public UUID getServerUuid() {
-        return serverUuid;
-    }
-
-    public void setServerUuid(@NonNull final UUID serverUuid) {
-        this.serverUuid = serverUuid;
-    }
-
-    public String getFeatureId() {
-        return featureId;
-    }
-
-    public String getCommandId() {
-        return commandId;
-    }
-
-    public JsonNode getCommandParams() {
-        return commandParams;
-    }
-
-    public void setCommandParams(@NonNull final JsonNode jsonNode) {
-        this.commandParams = jsonNode;
-    }
-
-    @Override
-    public String toString() {
-        return "(" + serverUuid + ", "
-                + featureId + ", "
-                + commandId + ", "
-                + commandParams + ")";
-    }
 }

--- a/orchestrator-client/src/main/java/de/fau/clients/orchestrator/tree/PropertyTreeNode.java
+++ b/orchestrator-client/src/main/java/de/fau/clients/orchestrator/tree/PropertyTreeNode.java
@@ -111,10 +111,11 @@ public class PropertyTreeNode extends DefaultMutableTreeNode implements Presenta
         try {
             final ExecutableServerCall executableServerCall = ExecutableServerCall.newBuilder(callBuilder.build()).build();
             final Future<String> futureCallResult = ServerManager.getInstance().getServerCallManager().runAsync(executableServerCall);
+            // todo fixme 3 seconds is most likely not enough for most observable commands
             lastResult = futureCallResult.get(MAX_SERVER_RESPONSE_TIME_IN_SEC, TimeUnit.SECONDS);
             wasSuccessful = true;
         } catch (final TimeoutException ex) {
-            final String msg = "Timeout: Server did not responde within " + MAX_SERVER_RESPONSE_TIME_IN_SEC + " sec.";
+            final String msg = "Timeout: Task did not finish within " + MAX_SERVER_RESPONSE_TIME_IN_SEC + " sec.";
             log.error(msg);
             lastResult = msg;
         } catch (final ExecutionException ex) {

--- a/orchestrator-client/src/main/java/de/fau/clients/orchestrator/tree/PropertyTreeNode.java
+++ b/orchestrator-client/src/main/java/de/fau/clients/orchestrator/tree/PropertyTreeNode.java
@@ -102,7 +102,7 @@ public class PropertyTreeNode extends DefaultMutableTreeNode implements Presenta
                 : SiLACall.Type.UNOBSERVABLE_PROPERTY;
         final SiLACall.Builder callBuilder = new SiLACall.Builder(
                 featCtx.getServerUuid(),
-                featCtx.getFeatureId(),
+                featCtx.getFullyQualifiedIdentifier(),
                 property.getIdentifier(),
                 callType
         );

--- a/orchestrator-client/src/main/resources/logback.xml
+++ b/orchestrator-client/src/main/resources/logback.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <property scope="context" name="base_logfile" value="${user.home}/.sila/sila-orchestrator.log" />
+
+    <appender name="stdout" class="ch.qos.logback.core.ConsoleAppender">
+        <Target>System.out</Target>
+        <encoder>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n</pattern>
+        </encoder>
+    </appender>
+    <appender name="file" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <!--See also http://logback.qos.ch/manual/appenders.html#RollingFileAppender-->
+        <File>${base_logfile}</File>
+        <encoder>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n</pattern>
+        </encoder>
+        <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
+            <maxIndex>10</maxIndex>
+            <FileNamePattern>${base_logfile}.%i</FileNamePattern>
+        </rollingPolicy>
+        <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
+            <MaxFileSize>5MB</MaxFileSize>
+        </triggeringPolicy>
+    </appender>
+    <root level="INFO">
+        <appender-ref ref="stdout"/>
+        <appender-ref ref="file"/>
+    </root>
+</configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,6 @@
     <packaging>pom</packaging>
 
     <modules>
-        <module>extern/sila_java/library</module>
         <module>orchestrator-client</module>
     </modules>
 </project>


### PR DESCRIPTION
Please check the CommandTaskModel class, I renamed the featureId JSON field to fullyQualifiedFeatureIdentifier. If you have persisted CommandTaskModel  you will need to migrate to fullyQualifiedFeatureIdentifier since the codebase has been updated to use fully qualified feature identifier because sila_java did it as well because features can clash with simple identifier. A simple example would be a server with two features that have the same identifier but a different major version.

- Remove sila_java submodule because sila_java is now available on Maven Central
- Remove unnecessary dependencies.
- Update sila_java to 0.10.0
- Update codebase to use fully qualified feature identifier instead of simple feature identifier
- Refactor ValidatorUtils
- Replace ServerAdditionException by server_management.ServerConnectionException
- Add log configuration since sila_java library does not provide it by default anymore to avoid duplicate log config
- Add fromString for FullyQualifiedIdentifier
